### PR TITLE
Removing old savon gem dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ rvm:
   - jruby-19mode
   - jruby-head
   - ruby-head
+gemfile:
+  - Gemfile
 env:
   - "rack=1.6.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 # Travis bug, see https://github.com/bundler/bundler/pull/3559
-before_install: gem update bundler
+before_install:
+  - gem install bundler
+  - gem update bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
+# Travis bug, see https://github.com/bundler/bundler/pull/3559
+before_install:
+  - gem install bundler
+  - gem update bundler
 rvm:
   - 1.9.3
   - 2.0.0
-  - jruby-19mode
-  - jruby-head
+  - jruby
   - ruby-head
 env:
   - "rack=1.6.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+# Travis bug, see https://github.com/bundler/bundler/pull/3559
+before_install: gem update bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: ruby
-# Travis bug, see https://github.com/bundler/bundler/pull/3559
-before_install:
-  - gem install bundler
-  - gem update bundler
 rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode
   - jruby-head
   - ruby-head
-gemfile:
-  - Gemfile
 env:
   - "rack=1.6.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ rvm:
   - jruby-19mode
   - jruby-head
   - ruby-head
+env:
+  - "rack=1.6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     payex (0.3)
       httpclient (~> 2.2)
-      nori (~> 2.6.0)
-      savon (~> 2.11.1)
+      nori (~> 2.6)
+      savon (~> 2.11)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,16 +3,16 @@ PATH
   specs:
     payex (0.3)
       httpclient (~> 2.2)
-      nori (~> 1.1)
-      savon (~> 1.1)
+      nori (~> 2.6.0)
+      savon (~> 2.11.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    akami (1.2.0)
+    akami (1.3.1)
       gyoku (>= 0.4.0)
-      nokogiri (>= 1.4.0)
-    builder (3.1.3)
+      nokogiri
+    builder (3.2.2)
     diff-lcs (1.1.3)
     guard (1.3.3)
       listen (>= 0.4.2)
@@ -22,15 +22,17 @@ GEM
       guard (~> 1.1)
     guard-rspec (1.2.1)
       guard (>= 1.1)
-    gyoku (0.4.6)
+    gyoku (1.3.1)
       builder (>= 2.1.2)
-    httpclient (2.3.4.1)
-    httpi (1.1.1)
+    httpclient (2.8.0)
+    httpi (2.4.1)
       rack
     listen (0.5.2)
-    nokogiri (1.5.5)
-    nori (1.1.3)
-    rack (1.4.1)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    nori (2.6.0)
+    rack (1.6.4)
     rake (0.9.2.2)
     rb-fsevent (0.9.2)
     rspec (2.11.0)
@@ -41,22 +43,19 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
-    savon (1.2.0)
-      akami (~> 1.2.0)
+    savon (2.11.1)
+      akami (~> 1.2)
       builder (>= 2.1.2)
-      gyoku (~> 0.4.5)
-      httpi (~> 1.1.0)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
       nokogiri (>= 1.4.0)
-      nori (~> 1.1.0)
-      wasabi (~> 2.5.0)
-    savon_spec (1.3.0)
-      rspec (>= 2.0.0)
-      savon (~> 1.0)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
     terminal-notifier-guard (1.5.3)
     thor (0.16.0)
-    wasabi (2.5.1)
-      httpi (~> 1.0)
-      nokogiri (>= 1.4.0)
+    wasabi (3.5.0)
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
 
 PLATFORMS
   ruby
@@ -70,5 +69,7 @@ DEPENDENCIES
   rake (~> 0.9)
   rb-fsevent (~> 0.9)
   rspec (~> 2.11)
-  savon_spec (~> 1.3)
   terminal-notifier-guard (~> 1.5)
+
+BUNDLED WITH
+   1.11.2

--- a/lib/payex/api.rb
+++ b/lib/payex/api.rb
@@ -15,7 +15,8 @@ module PayEx::API
     # Unwrap e.g. <Initialize8Result>
     response = response[response.keys.first]
     # Parse embedded XML document
-    response = Nori.parse(response)
+    parser = Nori.new(convert_tags_to: lambda { |tag| tag.snakecase.to_sym })
+    response = parser.parse(response)
     # Unwrap <payex>
     response = response[response.keys.first]
 
@@ -29,9 +30,7 @@ module PayEx::API
   end
 
   def invoke_raw! wsdl, name, body
-    Savon.client(wsdl).request(name, body: body) {
-      http.headers.delete('SOAPAction')
-    }.body
+    Savon.client(wsdl: wsdl).call(name, soap_action: false, message: body).body
   end
 
   def signed_hash(string)

--- a/lib/payex/api/pxorder.rb
+++ b/lib/payex/api/pxorder.rb
@@ -6,7 +6,7 @@ module PayEx::PxOrder
   end
 
   def Initialize7(params)
-    PayEx::API.invoke! wsdl, 'Initialize7', params, {
+    PayEx::API.invoke! wsdl, :initialize7, params, {
       'accountNumber' => {
         signed: true,
         default: proc { PayEx.account_number! }

--- a/lib/payex/api/pxorder.rb
+++ b/lib/payex/api/pxorder.rb
@@ -81,7 +81,7 @@ module PayEx::PxOrder
   end
 
   def Complete(params)
-    PayEx::API.invoke! wsdl, 'Complete', params, {
+    PayEx::API.invoke! wsdl, :complete, params, {
       'accountNumber' => {
         signed: true,
         default: proc { PayEx.account_number! }

--- a/payex.gemspec
+++ b/payex.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files 2>/dev/null`.split($\)
 
   gem.add_dependency 'httpclient', '~> 2.2'
-  gem.add_dependency 'nori', '~> 1.1'
-  gem.add_dependency 'savon', '~> 1.1'
+  gem.add_dependency 'nori', '~> 2.6'
+  gem.add_dependency 'savon', '~> 2.11'
 
   if RUBY_PLATFORM == 'java'
     gem.add_dependency 'jruby-openssl', '~> 0.7'
@@ -21,6 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency 'rb-fsevent', '~> 0.9'
   gem.add_development_dependency 'rspec', '~> 2.11'
-  gem.add_development_dependency 'savon_spec', '~> 1.3'
   gem.add_development_dependency 'terminal-notifier-guard', '~> 1.5'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,2 @@
-require 'savon_spec'
-
-Savon::Spec::Fixture.path =
-  File.expand_path('../fixtures', __FILE__)
-
-RSpec.configure do |config|
-  config.include Savon::Spec::Macros
-end
-
 # Suppress "HTTPI executes HTTP GET using the httpclient adapter"
 HTTPI.log = false


### PR DESCRIPTION
Ran into issues of gem dependencies with my other gems which were using 'savon' version 2 gem as dependency. So I updated the code to work with Savon 2 to remove conflict with other gems. I thought this will be useful for others too. Made changes in RSpec tests for new Savon version and now all tests are passing
