### PR TITLE
PayEx test environment API url updated.

### DIFF
--- a/lib/payex.rb
+++ b/lib/payex.rb
@@ -1,7 +1,7 @@
 module PayEx
   extend self
 
-  TEST_URL = 'https://test-external.payex.com'
+  TEST_URL = 'https://external.externaltest.payex.com/'
   LIVE_URL = 'https://external.payex.com'
 
   attr_accessor :base_url


### PR DESCRIPTION
According to technical documentation by PayEx;
The URL for our test environment is https://external.externaltest.payex.com/.

Here is the reference; http://www.payexpim.com/quick-guide/introduction/

I've tested this within node package that I've been working on and old testing URL does not work now.